### PR TITLE
fix: remove region parameter from aws_s3_bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket        = var.bucket_name
   acl           = var.enable_website ? "public-read" : var.acl
   policy        = var.bucket_policy
-  region        = var.region
   force_destroy = var.force_destroy
 
   dynamic "website" {


### PR DESCRIPTION
This parameter is no longer supported by Terraform against the S3
resource itself.

In order to support a region parameter for any megablocks action we will
likely need to use a provider alias which can default to the current
region if no region is specified.