### PR TITLE
fix: pin AWS provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,6 @@
+ terraform {
+    required_version = "~> 0.12"
+    required_providers {
+       aws = "~> 3.0"
+    }
+}


### PR DESCRIPTION
AWS provider version 4.0 breaks compatibility w/ previous S3 resources.